### PR TITLE
Add Python 3.10 to the testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py36,py37,py38,py39
+envlist=py27,py37,py38,py39,py310
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Also remove Python 3.5 and 3.6, because those versions have reached the
end of their supported lives.
