### PR TITLE
Conditionally format values for matching

### DIFF
--- a/ptracer/_syscall.py
+++ b/ptracer/_syscall.py
@@ -8,6 +8,12 @@ import functools
 import operator
 
 
+def _maybe_format(value):
+    if isinstance(value, (bytes, bytearray, str)):
+        return value
+    return '{}'.format(value)
+
+
 class SysCallPattern(object):
     def __init__(self, name=None, args=None, result=None):
         self.name = name
@@ -41,7 +47,7 @@ class SysCallPattern(object):
             getter = indirection
         elif hasattr(value, 'match'):
             checker = value.match
-            getter = lambda sc: '{}'.format(indirection(sc).value)
+            getter = lambda sc: _maybe_format(indirection(sc).value)
         else:
             checker = lambda v: v == value
             getter = lambda sc: indirection(sc).value

--- a/tests/test_ptracer.py
+++ b/tests/test_ptracer.py
@@ -115,6 +115,18 @@ class TestPtracer(unittest.TestCase):
                 name=re.compile('openat'),
                 args=[
                     None,
+                    re.compile(b'.*/null'),
+                ]
+            )
+        ])
+
+        self.assertEqual(len(syscalls), 1)
+
+        _trace([
+            ptracer.SysCallPattern(
+                name=re.compile('openat'),
+                args=[
+                    None,
                     None,
                     lambda arg: arg.value & os.O_WRONLY
                 ]


### PR DESCRIPTION
We previously always string-ified syscall values in preparation for
filtering them with 'match' checkers. This isn't the behavior we want
for 'byte' and 'byterray' values, however, because we'd end up matching
against their `__str__` representations (e.g. `bytearray(b'abc')`).

We now only format the value when it isn't one of (bytes, bytearray,
str), and we require the matcher to be bytes- or string-aware. (This is
something we could consider revisiting by attempting to decode bytes to
strings, to make matching more natural, but I don't know if that level
of implicit conversion is really needed for such a low-level library.)

Fixes #7